### PR TITLE
Search assets ec

### DIFF
--- a/app/controllers/serializedAsset.controller.js
+++ b/app/controllers/serializedAsset.controller.js
@@ -4,6 +4,7 @@ const AssetCategory = db.assetCategory;
 const AssetType = db.assetType;
 const AssetProfile = db.assetProfile;
 const SerializedAsset = db.serializedAsset;
+const Op = db.Sequelize.Op;
 
 // Create and Save a new SerializedAsset
 exports.createSerializedAsset = (req, res) => {
@@ -222,14 +223,14 @@ exports.searchSerializedAssets = async(req, res) => {
   try{
     if(searchKey){
       data = await findAssetsBySerialNumber(where, searchKey);
-      if(!data){
+      if(data.length < 1){
         data = await findAssetsByBarcode(where, searchKey);
       } 
     }
     else {
       data = await findAssetsByFilter(where);
     }
-    if(data){
+    if(data.length > 0){
       res.send(data);
     }
     else{

--- a/app/routes/serializedAsset.routes.js
+++ b/app/routes/serializedAsset.routes.js
@@ -11,6 +11,9 @@ module.exports = (app) => {
 
     // Retrieve all SerializedAssets
     router.get("/profile/:profileId", [authenticate], serializedAsset.getAllSerializedAssetsForProfile);
+
+    //Get serialized asset by search parameters
+    router.get("/search", [authenticate], serializedAsset.searchSerializedAssets);
   
     // Retrieve a single SerializedAsset by serializedAssetId
     router.get("/:serializedAssetId", [authenticate], serializedAsset.getSerializedAssetById);


### PR DESCRIPTION
Created new asset query to search filtered assets.

To test with postman: 
localhost:3031/asset-t1/serializedasset/search
for query parameters use searchKey for serial number or barcode. profileId for profile ID, and typeId for type ID. Leave unused parameters off of the string. 
 - Ex. Searching for serial No. 100001 - localhost:3031/asset-t1/serializedasset/search?searchKey=100001